### PR TITLE
Keep on going when experiencing unhandled apis.  Prevents errors like…

### DIFF
--- a/helm/kube-graffiti/Chart.yaml
+++ b/helm/kube-graffiti/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Graffiti kubernetes objects
 name: kube-graffiti
-version: 0.8.4
+version: 0.8.5

--- a/helm/kube-graffiti/values.yaml
+++ b/helm/kube-graffiti/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 # You can change the image (for testing)
 image:
   repository: hotelsdotcom/kube-graffiti
-  tag: 0.8.4
+  tag: 0.8.5
   pullPolicy: IfNotPresent
 
 # nameOverride and fullnameOverride allow you to change the way that the chart/release name is generated

--- a/pkg/existing/existing.go
+++ b/pkg/existing/existing.go
@@ -95,7 +95,6 @@ func discoverAPIsAndResources() error {
 	sliceOfResourceLists, err := discoveryClient.ServerResources()
 	if err != nil {
 		mylog.Error().Err(err).Msg("failed to look up kubernetes resources")
-		return fmt.Errorf("failed to discover kubernetes api resources: %v", err)
 	}
 	for _, gv := range sliceOfResourceLists {
 		discoveredResources[gv.GroupVersion] = gv.APIResources


### PR DESCRIPTION
… this one causing kube-graffiti to crash "unable to retrieve the complete list of server APIs: metrics.k8s.io/v1beta1: the server is currently unable to handle the request"

bump version to 0.8.5